### PR TITLE
remove description from documentation; resolves #8

### DIFF
--- a/docs/resources/license.md
+++ b/docs/resources/license.md
@@ -14,13 +14,11 @@ Provides a TG node license. The license will be stored in TF state.
 
 ```terraform
 resource "tg_license" "example" {
-  description = "License for example node"
-  name        = "my-example-node"
+  name = "my-example-node"
 }
 
 output "license" {
-  description = "Generated JWT license for example node"
-  value       = resource.tg_license.example.license
+  value = resource.tg_license.example.license
 }
 ```
 

--- a/examples/resources/tg_license/resource.tf
+++ b/examples/resources/tg_license/resource.tf
@@ -1,9 +1,7 @@
 resource "tg_license" "example" {
-  description = "License for example node"
-  name        = "my-example-node"
+  name = "my-example-node"
 }
 
 output "license" {
-  description = "Generated JWT license for example node"
-  value       = resource.tg_license.example.license
+  value = resource.tg_license.example.license
 }


### PR DESCRIPTION
Doesn't make sense to put a description on this locally since that isn't surfaced anywhere.