### PR TITLE
lock around entire vnet modification. resolves #43

### DIFF
--- a/poc/main.tf
+++ b/poc/main.tf
@@ -64,6 +64,22 @@ resource "tg_virtual_network_route" "route1" {
   description  = "a route2"
 }
 
+resource "tg_virtual_network_route" "route2" {
+  network      = resource.tg_virtual_network.testaringo.name
+  dest         = "node1-profiled"
+  network_cidr = "10.10.10.15/32"
+  metric       = 13
+  description  = "a route3"
+}
+
+resource "tg_virtual_network_route" "route3" {
+  network      = resource.tg_virtual_network.testaringo.name
+  dest         = "node1-profiled"
+  network_cidr = "10.10.10.16/32"
+  metric       = 14
+  description  = "a route4"
+}
+
 resource "tg_gateway_config" "test" {
   node_id = "x59838ae6-a2b2-4c45-b7be-9378f0b265f"
   enabled = true
@@ -93,6 +109,16 @@ resource "tg_virtual_network_access_rule" "acl1" {
   source      = "0.0.0.0/0"
   protocol    = "icmp"
   description = "ping"
+}
+
+resource "tg_virtual_network_access_rule" "acl2" {
+  action      = "allow"
+  network     = resource.tg_virtual_network.testaringo.name
+  line_number = 12
+  dest        = "0.0.0.0/0"
+  source      = "0.0.0.0/0"
+  protocol    = "any"
+  description = "evs"
 }
 
 resource "tg_ztna_gateway_config" "ztna1" {
@@ -516,7 +542,7 @@ data "tg_kvm_volume" "myvol" {
 
 resource "tg_node_state" "enable_gw" {
   node_id = "x59838ae6-a2b2-4c45-b7be-9378f0b265f"
-  enabled    = true
+  enabled = true
 }
 
 output "kvm-vol-size" {

--- a/resource/virtualnetwork.go
+++ b/resource/virtualnetwork.go
@@ -76,6 +76,9 @@ func (vn *virtualNetwork) Create(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
+	tgc.Lock.Lock()
+	defer tgc.Lock.Unlock()
+
 	if _, err := tgc.Post(ctx, "/v2/domain/"+tgc.Domain+"/network", &vnet); err != nil {
 		return diag.FromErr(err)
 	}
@@ -105,6 +108,9 @@ func (vn *virtualNetwork) Update(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
+	tgc.Lock.Lock()
+	defer tgc.Lock.Unlock()
+
 	if err := tgc.Put(ctx, "/v2/domain/"+tgc.Domain+"/network/"+vnet.Name, &vnet); err != nil {
 		return diag.FromErr(err)
 	}
@@ -123,6 +129,9 @@ func (vn *virtualNetwork) Delete(ctx context.Context, d *schema.ResourceData, me
 	if err := hcl.DecodeResourceData(d, &vnet); err != nil {
 		return diag.FromErr(err)
 	}
+
+	tgc.Lock.Lock()
+	defer tgc.Lock.Unlock()
 
 	if err := tgc.Delete(ctx, "/v2/domain/"+tgc.Domain+"/network/"+vnet.Name, &vnet); err != nil {
 		return diag.FromErr(err)

--- a/resource/vnetroute.go
+++ b/resource/vnetroute.go
@@ -93,6 +93,9 @@ func (vn *vnetRoute) Create(ctx context.Context, d *schema.ResourceData, meta an
 		return diag.FromErr(err)
 	}
 
+	tgc.Lock.Lock()
+	defer tgc.Lock.Unlock()
+
 	if _, err := tgc.Post(ctx, "/v2/domain/"+tgc.Domain+"/network/"+route.NetworkName+"/route", &route); err != nil {
 		return diag.FromErr(err)
 	}
@@ -122,6 +125,9 @@ func (vn *vnetRoute) Update(ctx context.Context, d *schema.ResourceData, meta an
 		return diag.FromErr(err)
 	}
 
+	tgc.Lock.Lock()
+	defer tgc.Lock.Unlock()
+
 	if err := tgc.Put(ctx, "/v2/domain/"+tgc.Domain+"/network/"+route.NetworkName+"/route/"+route.UID, &route); err != nil {
 		return diag.FromErr(err)
 	}
@@ -140,6 +146,9 @@ func (vn *vnetRoute) Delete(ctx context.Context, d *schema.ResourceData, meta an
 	if err := hcl.DecodeResourceData(d, &route); err != nil {
 		return diag.FromErr(err)
 	}
+
+	tgc.Lock.Lock()
+	defer tgc.Lock.Unlock()
 
 	if err := tgc.Delete(ctx, "/v2/domain/"+tgc.Domain+"/network/"+route.NetworkName+"/route/"+route.UID, &route); err != nil {
 		return diag.FromErr(err)

--- a/resource/vnetrule.go
+++ b/resource/vnetrule.go
@@ -118,6 +118,9 @@ func (vn *vnetAccessRule) Create(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
+	tgc.Lock.Lock()
+	defer tgc.Lock.Unlock()
+
 	if _, err := tgc.Post(ctx, vn.urlRoot(tgc, rule), &rule); err != nil {
 		return diag.FromErr(err)
 	}
@@ -147,6 +150,9 @@ func (vn *vnetAccessRule) Update(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
+	tgc.Lock.Lock()
+	defer tgc.Lock.Unlock()
+
 	if err := tgc.Put(ctx, vn.ruleURL(tgc, rule), &rule); err != nil {
 		return diag.FromErr(err)
 	}
@@ -165,6 +171,9 @@ func (vn *vnetAccessRule) Delete(ctx context.Context, d *schema.ResourceData, me
 	if err := hcl.DecodeResourceData(d, &rule); err != nil {
 		return diag.FromErr(err)
 	}
+
+	tgc.Lock.Lock()
+	defer tgc.Lock.Unlock()
 
 	if err := tgc.Delete(ctx, vn.ruleURL(tgc, rule), &rule); err != nil {
 		return diag.FromErr(err)

--- a/tg/client.go
+++ b/tg/client.go
@@ -13,6 +13,7 @@ import (
 )
 
 type Client struct {
+	Lock      sync.Mutex
 	writeLock sync.Mutex
 
 	APIHost   string


### PR DESCRIPTION
For changes that must be committed (vnet, vnet route, vnet acl), lock around the entire operation to prevent things changing out from under us. 

There's definitely a better way to do this. Needs some thought.