### PR TITLE
add ability to import and generate ztna gw wg keys. resolves #62

### DIFF
--- a/docs/resources/ztna_gateway_config.md
+++ b/docs/resources/ztna_gateway_config.md
@@ -49,10 +49,12 @@ resource "tg_ztna_gateway_config" "cluster_ztnagw" {
 - `port` (Number) Host Port
 - `wg_enabled` (Boolean) Enable the wireguard gateway feature
 - `wg_endpoint` (String) Wireguard endpoint
+- `wg_key` (String, Sensitive) Wireguard private key (base64) - if not provided, a key will be generated on `create` if wg_enabled is true
 - `wg_port` (Number) Wireguard port
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `wg_public_key` (String) Wireguard public key (base64)
 
 

--- a/poc/main.tf
+++ b/poc/main.tf
@@ -126,14 +126,18 @@ resource "tg_virtual_network_access_rule" "acl2" {
 }
 
 resource "tg_ztna_gateway_config" "ztna1" {
-  node_id     = "x59838ae6-a2b2-4c45-b7be-9378f0b265f"
+  node_id     = "59838ae6-a2b2-4c45-b7be-9378f0b265f5"
   enabled     = "true"
-  host        = "10.10.10.10"
+  host        = "10.10.10.101"
   port        = 8553
   cert        = "proxy.dev.trustgrid.io"
   wg_enabled  = true
   wg_port     = 8555
   wg_endpoint = "wg.dev.trustgrid.io"
+}
+
+output "wg_pubkey" {
+  value = resource.tg_ztna_gateway_config.ztna1.wg_public_key
 }
 
 resource "tg_ztna_gateway_config" "clusterztna" {

--- a/resource/ztnaconfig.go
+++ b/resource/ztnaconfig.go
@@ -2,6 +2,8 @@ package resource
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -10,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/trustgrid/terraform-provider-tg/hcl"
 	"github.com/trustgrid/terraform-provider-tg/tg"
+	"golang.org/x/crypto/curve25519"
 )
 
 type ztnaConfig struct{}
@@ -34,11 +37,12 @@ func ZTNAConfig() *schema.Resource {
 				ExactlyOneOf: []string{"node_id", "cluster_fqdn"},
 			},
 			"cluster_fqdn": {
-				Description:  "Cluster FQDN - required if node_id is not set",
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ExactlyOneOf: []string{"node_id", "cluster_fqdn"},
+				Description:   "Cluster FQDN - required if node_id is not set",
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ExactlyOneOf:  []string{"node_id", "cluster_fqdn"},
+				ConflictsWith: []string{"wg_key"},
 			},
 			"enabled": {
 				Description: "Enable the gateway plugin",
@@ -79,6 +83,18 @@ func ZTNAConfig() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: validation.IntBetween(1, 65535),
 			},
+			"wg_key": {
+				Description:   "Wireguard private key (base64) - if not provided, a key will be generated on `create` if wg_enabled is true",
+				Type:          schema.TypeString,
+				Optional:      true,
+				Sensitive:     true,
+				ConflictsWith: []string{"cluster_fqdn"},
+			},
+			"wg_public_key": {
+				Description: "Wireguard public key (base64)",
+				Computed:    true,
+				Type:        schema.TypeString,
+			},
 			"cert": {
 				Description: "Certificate",
 				Type:        schema.TypeString,
@@ -89,6 +105,63 @@ func ZTNAConfig() *schema.Resource {
 	}
 }
 
+const _ztnaWGKey = "tg-apigw-wg"
+
+// readWGKey reads the WG public key for the ztna gateway from the TG API
+func (z *ztnaConfig) readWGKey(ctx context.Context, tgc *tg.Client, nodeID string) (string, error) {
+	n := tg.Node{}
+	err := tgc.Get(ctx, "/node/"+nodeID, &n)
+	if err != nil {
+		return "", fmt.Errorf("getting node: %w", err)
+	}
+
+	if k, ok := n.Keys[_ztnaWGKey]; ok {
+		return k.X, nil
+	}
+
+	return "", nil
+}
+
+// createWGKey imports or generates the WG key for ztna gw, and returns the public key
+func (z *ztnaConfig) createWGKey(ctx context.Context, tgc *tg.Client, gw tg.ZTNAConfig) (string, error) {
+	var keyReply tg.PublicKey
+
+	var keyRequest struct {
+		Action  string `json:"action"`
+		Name    string `json:"name"`
+		Network string `json:"network"`
+		Key     string `json:"key,omitempty"`
+	}
+
+	keyRequest.Name = "apigw-wg-key"
+	keyRequest.Network = "tg-apigw"
+
+	if gw.WireguardPrivateKey == "" {
+		keyRequest.Action = "generate"
+	} else {
+		keyRequest.Action = "save"
+		keyRequest.Key = gw.WireguardPrivateKey
+	}
+
+	res, err := tgc.Post(ctx, "/node/"+gw.NodeID+"/trigger/apigw-wg-key?wait=1", keyRequest)
+	if err != nil {
+		return "", fmt.Errorf("saving key: %w", err)
+	}
+
+	if err := json.Unmarshal(res, &keyReply); err != nil {
+		return "", fmt.Errorf("unmarshalling import key reply: %w", err)
+	}
+
+	err = tgc.Put(ctx, "/node/"+gw.NodeID+"/keys/"+_ztnaWGKey, keyReply)
+	if err != nil {
+		return "", fmt.Errorf("saving key: %w", err)
+	}
+
+	return keyReply.X, nil
+}
+
+// Create writes initial ZTNA config and, if wireguard is enabled and the subject being configured is a node,
+// will either generate a wg key or import the provided one.
 func (z *ztnaConfig) Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	tgc := meta.(*tg.Client)
 	gw := tg.ZTNAConfig{}
@@ -108,6 +181,16 @@ func (z *ztnaConfig) Create(ctx context.Context, d *schema.ResourceData, meta an
 		d.SetId(gw.ClusterFQDN)
 	}
 
+	if gw.WireguardEnabled && gw.NodeID != "" {
+		pk, err := z.createWGKey(ctx, tgc, gw)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if err := d.Set("wg_public_key", pk); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	return nil
 }
 
@@ -118,6 +201,7 @@ func (z *ztnaConfig) url(c tg.ZTNAConfig) string {
 	return fmt.Sprintf("/cluster/%s/config/ztnagw", c.ClusterFQDN)
 }
 
+// Read fetches the ZTNA gateway config and the ZTNA WG key from the TG API
 func (z *ztnaConfig) Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	tgc := meta.(*tg.Client)
 	gw := tg.ZTNAConfig{}
@@ -126,13 +210,14 @@ func (z *ztnaConfig) Read(ctx context.Context, d *schema.ResourceData, meta any)
 		return diag.FromErr(err)
 	}
 
-	ztna := tg.ZTNAConfig{}
+	var ztna tg.ZTNAConfig
 
 	if gw.NodeID != "" {
 		n := tg.Node{}
 		err = tgc.Get(ctx, "/node/"+d.Id(), &n)
 		ztna = n.Config.ZTNA
 		ztna.NodeID = gw.NodeID
+		ztna.WireguardPrivateKey = gw.WireguardPrivateKey
 	} else {
 		c := tg.Cluster{}
 		err = tgc.Get(ctx, "/cluster/"+d.Id(), &c)
@@ -148,6 +233,14 @@ func (z *ztnaConfig) Read(ctx context.Context, d *schema.ResourceData, meta any)
 		return diag.FromErr(err)
 	}
 
+	if gw.NodeID != "" {
+		pk, err := z.readWGKey(ctx, tgc, gw.NodeID)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		ztna.WireguardPublicKey = pk
+	}
+
 	if err := hcl.EncodeResourceData(&ztna, d); err != nil {
 		return diag.FromErr(err)
 	}
@@ -155,10 +248,61 @@ func (z *ztnaConfig) Read(ctx context.Context, d *schema.ResourceData, meta any)
 	return nil
 }
 
-func (z *ztnaConfig) Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	return z.Create(ctx, d, meta)
+func (z *ztnaConfig) derivePublicKey(privateKey string) (string, error) {
+	decoded, err := base64.StdEncoding.DecodeString(privateKey)
+	if err != nil {
+		return "", fmt.Errorf("decoding private key: %w", err)
+	}
+	var decodedPrivateKey [32]byte
+	copy(decodedPrivateKey[:], decoded)
+	var pubKey [32]byte
+	curve25519.ScalarBaseMult(&pubKey, &decodedPrivateKey)
+
+	return base64.StdEncoding.EncodeToString(pubKey[:]), nil
 }
 
+// Update sends the local TF config to the TG API for ZTNA config, and if a wireguard private key is provided,
+// imports and updates the key (if needed).
+func (z *ztnaConfig) Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	tgc := meta.(*tg.Client)
+	gw := tg.ZTNAConfig{}
+	err := hcl.DecodeResourceData(d, &gw)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = tgc.Put(ctx, z.url(gw), &gw)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if gw.NodeID != "" {
+		d.SetId(gw.NodeID)
+
+		if gw.WireguardPrivateKey != "" {
+			derived, err := z.derivePublicKey(gw.WireguardPrivateKey)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+
+			if derived != gw.WireguardPublicKey {
+				pk, err := z.createWGKey(ctx, tgc, gw)
+				if err != nil {
+					return diag.FromErr(err)
+				}
+				if err := d.Set("wg_public_key", pk); err != nil {
+					return diag.FromErr(err)
+				}
+			}
+		}
+	} else {
+		d.SetId(gw.ClusterFQDN)
+	}
+
+	return nil
+}
+
+// Delete blanks out most of the ZTNA gateway config and sets enabled/wireguardEnabled to false
 func (z *ztnaConfig) Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	tgc := meta.(*tg.Client)
 	gw := tg.ZTNAConfig{}

--- a/tg/node.go
+++ b/tg/node.go
@@ -55,6 +55,9 @@ type ZTNAConfig struct {
 	WireguardEndpoint string `tf:"wg_endpoint" json:"wireguardEndpoint"`
 	WireguardPort     int    `tf:"wg_port" json:"wireguardPort"`
 	WireguardEnabled  bool   `tf:"wg_enabled" json:"wireguardEnabled"`
+
+	WireguardPrivateKey string `tf:"wg_key" json:"-"`
+	WireguardPublicKey  string `tf:"wg_public_key" json:"-"`
 }
 
 type ClusterConfig struct {
@@ -168,13 +171,21 @@ type NetworkConfig struct {
 	VRFs []VRF `json:"vrfs,omitempty"`
 }
 
+type PublicKey struct {
+	CRV string `json:"crv"`
+	KID string `json:"kid"`
+	KTY string `json:"kty"`
+	X   string `json:"x"`
+}
+
 type Node struct {
-	UID     string            `json:"uid"`
-	State   string            `json:"state"`
-	Name    string            `json:"name"`
-	FQDN    string            `json:"fqdn"`
-	Cluster string            `json:"cluster"`
-	Tags    map[string]string `json:"tags" `
+	UID     string               `json:"uid"`
+	State   string               `json:"state"`
+	Name    string               `json:"name"`
+	FQDN    string               `json:"fqdn"`
+	Cluster string               `json:"cluster"`
+	Keys    map[string]PublicKey `json:"keys"`
+	Tags    map[string]string    `json:"tags" `
 	Config  struct {
 		Gateway GatewayConfig `json:"gateway"`
 		SNMP    SNMPConfig    `json:"snmp"`


### PR DESCRIPTION
Changes the way ZTNA gateway config setup works for nodes.

On `create`, if a `wg_key` is not present, but `wireguard_enabled` is true, a keypair will be generated. Other resources can consume the `wg_public_key` output. If a `wg_key` is present, it will be imported.

On `update`, if a `wg_key` is present but appears different than what's stored (base on public key comparison), the key will be reimported.

There is no way to generate a wg key after ZTNA has been configured, aside from deleting the resource and recreating it.