### PR TITLE
change route and cloud route entries for network config to take structs. resolves #54

### DIFF
--- a/docs/resources/network_config.md
+++ b/docs/resources/network_config.md
@@ -54,12 +54,20 @@ resource "tg_network_config" "network-1" {
   }
 
   interface {
-    nic          = "ens192"
-    dhcp         = false
-    gateway      = "10.20.10.1"
-    ip           = "10.20.10.50/24"
-    routes       = ["10.10.10.0/24"]
-    cloud_routes = ["10.10.14.0/24"]
+    nic     = "ens192"
+    dhcp    = false
+    gateway = "10.20.10.1"
+    ip      = "10.20.10.50/24"
+
+    route {
+      route       = "10.10.10.0/24"
+      description = "interface route"
+    }
+
+    cloud_route {
+      route       = "10.10.14.0/24"
+      description = "a cloud route"
+    }
   }
 
   interface {
@@ -162,7 +170,7 @@ Required:
 
 Optional:
 
-- `cloud_routes` (List of String) Cluster interface routes
+- `cloud_route` (Block List) Cluster interface routes (see [below for nested schema](#nestedblock--interface--cloud_route))
 - `cluster_ip` (String) Cluster IP
 - `dhcp` (Boolean) Enable DHCP
 - `dns` (List of String) DNS servers
@@ -170,8 +178,32 @@ Optional:
 - `gateway` (String) Gateway IP address
 - `ip` (String) IP address
 - `mode` (String) Interface mode
-- `routes` (List of String) Interface routes
+- `route` (Block List) Interface routes (see [below for nested schema](#nestedblock--interface--route))
 - `speed` (Number) Interface speed
+
+<a id="nestedblock--interface--cloud_route"></a>
+### Nested Schema for `interface.cloud_route`
+
+Required:
+
+- `route` (String) Protocol
+
+Optional:
+
+- `description` (String) Description
+
+
+<a id="nestedblock--interface--route"></a>
+### Nested Schema for `interface.route`
+
+Required:
+
+- `route` (String) Protocol
+
+Optional:
+
+- `description` (String) Description
+
 
 
 <a id="nestedblock--tunnel"></a>

--- a/examples/resources/tg_network_config/resource.tf
+++ b/examples/resources/tg_network_config/resource.tf
@@ -40,12 +40,20 @@ resource "tg_network_config" "network-1" {
   }
 
   interface {
-    nic          = "ens192"
-    dhcp         = false
-    gateway      = "10.20.10.1"
-    ip           = "10.20.10.50/24"
-    routes       = ["10.10.10.0/24"]
-    cloud_routes = ["10.10.14.0/24"]
+    nic     = "ens192"
+    dhcp    = false
+    gateway = "10.20.10.1"
+    ip      = "10.20.10.50/24"
+
+    route {
+      route       = "10.10.10.0/24"
+      description = "interface route"
+    }
+
+    cloud_route {
+      route       = "10.10.14.0/24"
+      description = "a cloud route"
+    }
   }
 
   interface {

--- a/hcl/networkconfig.go
+++ b/hcl/networkconfig.go
@@ -28,18 +28,23 @@ type NetworkTunnel struct {
 	LocalSubnet   string `tf:"local_subnet,omitempty"`
 }
 
+type NetworkRoute struct {
+	Route       string `tf:"route"`
+	Description string `tf:"description"`
+}
+
 type NetworkInterface struct {
-	NIC         string   `tf:"nic"`
-	Routes      []string `tf:"routes,omitempty"`
-	CloudRoutes []string `tf:"cloud_routes,omitempty"`
-	ClusterIP   string   `tf:"cluster_ip,omitempty"`
-	DHCP        bool     `tf:"dhcp"`
-	Gateway     string   `tf:"gateway"`
-	IP          string   `tf:"ip"`
-	Mode        string   `tf:"mode,omitempty"`
-	DNS         []string `tf:"dns,omitempty"`
-	Duplex      string   `tf:"duplex,omitempty"`
-	Speed       int      `tf:"speed,omitempty"`
+	NIC         string         `tf:"nic"`
+	Routes      []NetworkRoute `tf:"route,omitempty"`
+	CloudRoutes []NetworkRoute `tf:"cloud_route,omitempty"`
+	ClusterIP   string         `tf:"cluster_ip,omitempty"`
+	DHCP        bool           `tf:"dhcp"`
+	Gateway     string         `tf:"gateway"`
+	IP          string         `tf:"ip"`
+	Mode        string         `tf:"mode,omitempty"`
+	DNS         []string       `tf:"dns,omitempty"`
+	Duplex      string         `tf:"duplex,omitempty"`
+	Speed       int            `tf:"speed,omitempty"`
 }
 
 type VRFACL struct {
@@ -144,10 +149,16 @@ func (h *NetworkConfig) UpdateFromTG(c tg.NetworkConfig) {
 		}
 
 		for _, r := range i.Routes {
-			iface.Routes = append(iface.Routes, r.Route)
+			iface.Routes = append(iface.Routes, NetworkRoute{
+				Route:       r.Route,
+				Description: r.Description,
+			})
 		}
 		for _, r := range i.CloudRoutes {
-			iface.CloudRoutes = append(iface.CloudRoutes, r.Route)
+			iface.CloudRoutes = append(iface.CloudRoutes, NetworkRoute{
+				Route:       r.Route,
+				Description: r.Description,
+			})
 		}
 		h.Interfaces = append(h.Interfaces, iface)
 	}
@@ -252,10 +263,10 @@ func (h *NetworkConfig) ToTG() tg.NetworkConfig {
 			DNS:       i.DNS,
 		}
 		for _, r := range i.Routes {
-			iface.Routes = append(iface.Routes, tg.NetworkRoute{Route: r})
+			iface.Routes = append(iface.Routes, tg.NetworkRoute{Route: r.Route, Description: r.Description})
 		}
 		for _, r := range i.CloudRoutes {
-			iface.CloudRoutes = append(iface.CloudRoutes, tg.NetworkRoute{Route: r})
+			iface.CloudRoutes = append(iface.CloudRoutes, tg.NetworkRoute{Route: r.Route, Description: r.Description})
 		}
 
 		nc.Interfaces = append(nc.Interfaces, iface)

--- a/poc/main.tf
+++ b/poc/main.tf
@@ -228,6 +228,16 @@ resource "tg_network_config" "network-1" {
 
   interface {
     nic = "ens192"
+    cloud_route {
+      route       = "10.100.0.0/16"
+      description = "edge network"
+    }
+
+    route {
+      route       = "5.5.5.5/32"
+      description = "whatever"
+    }
+
     #dhcp    = false
     #gateway = "10.20.10.1"
     #ip      = "10.20.10.50/24"

--- a/resource/networkconfig.go
+++ b/resource/networkconfig.go
@@ -253,22 +253,44 @@ func NetworkConfig() *schema.Resource {
 							Description:  "Cluster IP",
 							ValidateFunc: validation.IsIPv4Address,
 						},
-						"routes": {
+						"route": {
 							Description: "Interface routes",
 							Type:        schema.TypeList,
 							Optional:    true,
-							Elem: &schema.Schema{
-								Type:         schema.TypeString,
-								ValidateFunc: validation.IsCIDR,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"route": {
+										Description:  "Protocol",
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.IsCIDR,
+									},
+									"description": {
+										Description: "Description",
+										Type:        schema.TypeString,
+										Optional:    true,
+									},
+								},
 							},
 						},
-						"cloud_routes": {
+						"cloud_route": {
 							Description: "Cluster interface routes",
 							Type:        schema.TypeList,
 							Optional:    true,
-							Elem: &schema.Schema{
-								Type:         schema.TypeString,
-								ValidateFunc: validation.IsCIDR,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"route": {
+										Description:  "Protocol",
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.IsCIDR,
+									},
+									"description": {
+										Description: "Description",
+										Type:        schema.TypeString,
+										Optional:    true,
+									},
+								},
 							},
 						},
 						"dhcp": {

--- a/tg/node.go
+++ b/tg/node.go
@@ -129,7 +129,8 @@ type NetworkTunnel struct {
 }
 
 type NetworkRoute struct {
-	Route string `json:"route"`
+	Route       string `json:"route"`
+	Description string `json:"description,omitempty"`
 }
 
 type NetworkInterface struct {


### PR DESCRIPTION
**BREAKING CHANGE**

this changes `routes` and `cloud_routes` from being array fields, like 

    routes = [1.2.3.0/24]
    cloud_routes = [4.4.4.0/24]

to now take richer entries, so for each route you'd type

    route {
      route = "1.2.3.4/24"
      description = "an optional description"
    }

similarly, cloud routes are now:

    cloud_route {
      route = "4.4.4.0/24"
      description = "whatever"
    }