### PR TITLE
add docs for vpn dependency mgmt

### DIFF
--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -73,7 +73,7 @@ resource "tg_app" "mywgapp" {
 - `session_duration` (Number) Session Duration
 - `tls_verification_mode` (String) TLS Verification Mode
 - `trust_mode` (String) Trust Mode
-- `virtual_network` (String) Virtual network name
+- `virtual_network` (String) Virtual network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph
 - `virtual_source_ip` (String) Virtual source IP, if using a virtual network
 - `visibility_groups` (List of String) Visibility Groups
 - `vrf` (String) VRF

--- a/docs/resources/container.md
+++ b/docs/resources/container.md
@@ -221,7 +221,7 @@ Read-Only:
 Required:
 
 - `ip` (String) Virtual IP address
-- `network` (String) Virtual network name to attach
+- `network` (String) Virtual network name to attach - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph
 
 Optional:
 

--- a/docs/resources/virtual_network_access_rule.md
+++ b/docs/resources/virtual_network_access_rule.md
@@ -32,7 +32,7 @@ resource "tg_virtual_network_access_rule" "acl1" {
 - `action` (String) Allow/Reject/Drop
 - `dest` (String) Destination CIDR or exact string "public" or "private"
 - `line_number` (Number) Line Number
-- `network` (String) Virtual network name
+- `network` (String) Virtual network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph
 - `protocol` (String) Protocol
 - `source` (String) Source CIDR
 

--- a/docs/resources/virtual_network_attachment.md
+++ b/docs/resources/virtual_network_attachment.md
@@ -32,7 +32,7 @@ resource "tg_virtual_network_attachment" "tftest1" {
 
 ### Required
 
-- `network` (String) Virtual network name
+- `network` (String) Virtual network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph
 
 ### Optional
 

--- a/docs/resources/virtual_network_group.md
+++ b/docs/resources/virtual_network_group.md
@@ -25,7 +25,7 @@ resource "tg_virtual_network_group" "my-network-group" {
 ### Required
 
 - `name` (String) Group name
-- `network` (String) Virtual network name
+- `network` (String) Virtual network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph
 
 ### Optional
 

--- a/docs/resources/virtual_network_group_membership.md
+++ b/docs/resources/virtual_network_group_membership.md
@@ -26,7 +26,7 @@ resource "tg_virtual_network_group_membership" "membership_example" {
 ### Required
 
 - `group` (String) Group name
-- `network` (String) Virtual network name
+- `network` (String) Virtual network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph
 - `object` (String) Object name
 
 ### Read-Only

--- a/docs/resources/virtual_network_object.md
+++ b/docs/resources/virtual_network_object.md
@@ -27,7 +27,7 @@ resource "tg_virtual_network_object" "my_object" {
 
 - `cidr` (String) Object CIDR
 - `name` (String) Object name
-- `network` (String) Virtual network name
+- `network` (String) Virtual network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph
 
 ### Read-Only
 

--- a/docs/resources/virtual_network_port_forward.md
+++ b/docs/resources/virtual_network_port_forward.md
@@ -28,7 +28,7 @@ resource "tg_virtual_network_port_forward" "port_forward1" {
 ### Required
 
 - `ip` (String) IP address
-- `network` (String) Virtual network name
+- `network` (String) Virtual network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph
 - `node` (String) Node or Cluster name
 - `port` (Number) Port
 - `service` (String) Destination service name

--- a/docs/resources/virtual_network_route.md
+++ b/docs/resources/virtual_network_route.md
@@ -29,7 +29,7 @@ resource "tg_virtual_network_route" "route1" {
 
 - `dest` (String) Destination Node or Cluster name
 - `metric` (Number) Metric
-- `network` (String) Virtual network name
+- `network` (String) Virtual network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph
 - `network_cidr` (String) Network CIDR
 
 ### Optional

--- a/docs/resources/vpn_attachment.md
+++ b/docs/resources/vpn_attachment.md
@@ -32,7 +32,7 @@ resource "tg_vpn_attachment" "tftest1" {
 
 ### Required
 
-- `network` (String) Virtual network name
+- `network` (String) Virtual network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph
 
 ### Optional
 

--- a/docs/resources/vpn_dynamic_export_route.md
+++ b/docs/resources/vpn_dynamic_export_route.md
@@ -19,7 +19,7 @@ Manage a VPN dynamic export route on a node or cluster.
 
 - `metric` (Number) Metric
 - `network_cidr` (String) Network CIDR
-- `network_name` (String) Network name
+- `network_name` (String) Network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph
 - `node` (String) Node ID
 
 ### Optional

--- a/docs/resources/vpn_dynamic_import_route.md
+++ b/docs/resources/vpn_dynamic_import_route.md
@@ -19,7 +19,7 @@ Manage a VPN dynamic import route on a node or cluster.
 
 - `metric` (Number) Metric
 - `network_cidr` (String) Network CIDR
-- `network_name` (String) Network name
+- `network_name` (String) Network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph
 - `node` (String) Node ID
 
 ### Optional

--- a/docs/resources/vpn_interface.md
+++ b/docs/resources/vpn_interface.md
@@ -72,7 +72,7 @@ resource "tg_vpn_interface" "cluster-ipsec" {
 ### Required
 
 - `interface_name` (String) Interface name
-- `network` (String) Virtual network name
+- `network` (String) Virtual network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph
 
 ### Optional
 

--- a/docs/resources/vpn_static_route.md
+++ b/docs/resources/vpn_static_route.md
@@ -19,7 +19,7 @@ Manage a VPN static route on a node or cluster.
 
 - `metric` (Number) Metric
 - `network_cidr` (String) Network CIDR
-- `network_name` (String) Network name
+- `network_name` (String) Network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph
 - `node` (String) Node ID
 
 ### Optional

--- a/resource/app.go
+++ b/resource/app.go
@@ -113,7 +113,7 @@ func App() *schema.Resource {
 				Optional:    true,
 			},
 			"virtual_network": {
-				Description: "Virtual network name",
+				Description: "Virtual network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph",
 				Type:        schema.TypeString,
 				Optional:    true,
 			},

--- a/resource/container.go
+++ b/resource/container.go
@@ -414,7 +414,7 @@ func Container() *schema.Resource {
 						"network": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "Virtual network name to attach",
+							Description: "Virtual network name to attach - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph",
 						},
 						"ip": {
 							Type:        schema.TypeString,

--- a/resource/vnetattachment.go
+++ b/resource/vnetattachment.go
@@ -51,7 +51,7 @@ func VPNAttachment() *schema.Resource {
 				ExactlyOneOf: []string{"node_id", "cluster_fqdn"},
 			},
 			"network": {
-				Description: "Virtual network name",
+				Description: "Virtual network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph",
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,

--- a/resource/vnetgroup.go
+++ b/resource/vnetgroup.go
@@ -30,7 +30,7 @@ func VNetGroup() *schema.Resource {
 				Required:    true,
 			},
 			"network": {
-				Description: "Virtual network name",
+				Description: "Virtual network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph",
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,

--- a/resource/vnetgroup_membership.go
+++ b/resource/vnetgroup_membership.go
@@ -36,7 +36,7 @@ func VNetGroupMembership() *schema.Resource {
 				ForceNew:    true,
 			},
 			"network": {
-				Description: "Virtual network name",
+				Description: "Virtual network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph",
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,

--- a/resource/vnetobject.go
+++ b/resource/vnetobject.go
@@ -30,7 +30,7 @@ func VNetObject() *schema.Resource {
 				Required:    true,
 			},
 			"network": {
-				Description: "Virtual network name",
+				Description: "Virtual network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph",
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,

--- a/resource/vnetportforward.go
+++ b/resource/vnetportforward.go
@@ -33,7 +33,7 @@ func VNetPortForward() *schema.Resource {
 				Computed:    true,
 			},
 			"network": {
-				Description: "Virtual network name",
+				Description: "Virtual network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph",
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,

--- a/resource/vnetroute.go
+++ b/resource/vnetroute.go
@@ -32,7 +32,7 @@ func VNetRoute() *schema.Resource {
 				Computed:    true,
 			},
 			"network": {
-				Description: "Virtual network name",
+				Description: "Virtual network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph",
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,

--- a/resource/vnetrule.go
+++ b/resource/vnetrule.go
@@ -32,7 +32,7 @@ func VNetAccessRule() *schema.Resource {
 				Computed:    true,
 			},
 			"network": {
-				Description: "Virtual network name",
+				Description: "Virtual network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph",
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,

--- a/resource/vpn_dynamic_export_route.go
+++ b/resource/vpn_dynamic_export_route.go
@@ -102,7 +102,7 @@ func VPNDynamicExportRoute() *schema.Resource {
 				ExactlyOneOf: []string{"node_id", "cluster_fqdn"},
 			},
 			"network_name": {
-				Description: "Network name",
+				Description: "Network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph",
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,

--- a/resource/vpn_dynamic_import_route.go
+++ b/resource/vpn_dynamic_import_route.go
@@ -102,7 +102,7 @@ func VPNDynamicImportRoute() *schema.Resource {
 				ExactlyOneOf: []string{"node_id", "cluster_fqdn"},
 			},
 			"network_name": {
-				Description: "Network name",
+				Description: "Network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph",
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,

--- a/resource/vpn_interface.go
+++ b/resource/vpn_interface.go
@@ -81,7 +81,7 @@ func VPNInterface() *schema.Resource {
 				ExactlyOneOf: []string{"node_id", "cluster_fqdn"},
 			},
 			"network": {
-				Description: "Virtual network name",
+				Description: "Virtual network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph",
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,

--- a/resource/vpn_static_route.go
+++ b/resource/vpn_static_route.go
@@ -102,7 +102,7 @@ func VPNStaticRoute() *schema.Resource {
 				ExactlyOneOf: []string{"node_id", "cluster_fqdn"},
 			},
 			"network_name": {
-				Description: "Network name",
+				Description: "Network name - use the tg_virtual_network resource's exported name to help Terraform build a consistent dependency graph",
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,


### PR DESCRIPTION
resolves #179

I don't want to change up the VPN resource yet to support nesting everything, though that would solve this more gracefully. For now we can just encourage users to use resource.tg_vpn.name so the dep graph is consistent.


# Related issue

- Resolve #179