### PR TITLE
feat: add route monitor support to tg_virtual_network_route

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: 1.24
+          go-version-file: go.mod
 
       - name: Import GPG key
         id: import_gpg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,11 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@5f32ed9ef53c4f4b7f2e3c0555d88c5cb6d9d3ff # v4
+        with:
+          terraform_wrapper: false
+
       - name: test
         run: |
           make sweep testacc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@5f32ed9ef53c4f4b7f2e3c0555d88c5cb6d9d3ff # v4
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4
         with:
           terraform_wrapper: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: 1.24
+          go-version-file: go.mod
 
       - name: golang lint
         uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: 1.24
+          go-version-file: go.mod
 
       - name: test
         run: |

--- a/acctests/virtualnetwork_test.go
+++ b/acctests/virtualnetwork_test.go
@@ -70,7 +70,7 @@ func init() {
 
 	resource.AddTestSweepers("tg_virtualnetwork", &resource.Sweeper{
 		Name:         "tg_virtualnetwork",
-		Dependencies: []string{"tg_vpn_attachment"},
+		Dependencies: []string{"tg_vpn_attachment", "tg_virtual_network_route"},
 		F: func(r string) error {
 			cp := tg.ClientParams{
 				APIKey:    os.Getenv("TG_API_KEY_ID"),

--- a/acctests/vnetroute_test.go
+++ b/acctests/vnetroute_test.go
@@ -1,0 +1,230 @@
+package acctests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-testing/compare"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/trustgrid/terraform-provider-tg/provider"
+	"github.com/trustgrid/terraform-provider-tg/tg"
+)
+
+func init() {
+	resource.AddTestSweepers("tg_virtual_network_route", &resource.Sweeper{
+		Name:         "tg_virtual_network_route",
+		Dependencies: []string{"tg_vpn_attachment"},
+		F: func(r string) error {
+			cp := tg.ClientParams{
+				APIKey:    os.Getenv("TG_API_KEY_ID"),
+				APISecret: os.Getenv("TG_API_KEY_SECRET"),
+				APIHost:   os.Getenv("TG_API_HOST"),
+			}
+			client, err := tg.NewClient(context.Background(), cp)
+			if err != nil {
+				return fmt.Errorf("error creating client: %w", err)
+			}
+
+			var vnets []tg.VirtualNetwork
+			if err := client.Get(context.Background(), "/v2/domain/"+client.Domain+"/network", &vnets); err != nil {
+				return fmt.Errorf("error listing virtual networks: %w", err)
+			}
+
+			for _, vnet := range vnets {
+				if !strings.HasPrefix(vnet.Name, testVNetPrefix) {
+					continue
+				}
+
+				var routes []tg.VNetRoute
+				if err := client.Get(context.Background(), "/v2/domain/"+client.Domain+"/network/"+vnet.Name+"/route", &routes); err != nil {
+					return fmt.Errorf("error listing routes for %s: %w", vnet.Name, err)
+				}
+
+				for _, route := range routes {
+					if err := client.Delete(context.Background(), "/v2/domain/"+client.Domain+"/network/"+vnet.Name+"/route/"+route.UID, nil); err != nil {
+						return fmt.Errorf("error deleting route %s for %s: %w", route.UID, vnet.Name, err)
+					}
+				}
+			}
+
+			return nil
+		},
+	})
+}
+
+func TestAccVNetRoute_HappyPath(t *testing.T) {
+	compareValuesSame := statecheck.CompareValue(compare.ValuesSame())
+	networkName := newTestVNetName("route-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum))
+
+	tgProvider := provider.New("test")()
+
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]*schema.Provider{
+			"tg": tgProvider,
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: vnetRouteConfig(networkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("tg_virtual_network_route.test", "id"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "network", networkName),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "dest", "test-subject"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "network_cidr", "10.10.24.24/32"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "metric", "10"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "description", "Test Virtual Network Route"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "monitor.0.name", "tcp-probe"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "monitor.0.enabled", "true"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "monitor.0.protocol", "tcp"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "monitor.0.dest", "10.100.0.10"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "monitor.0.port", "443"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "monitor.0.interval", "5"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "monitor.0.count", "3"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "monitor.0.max_latency", "500"),
+					checkVNetRouteAPISide(tgProvider, networkName, func(route tg.VNetRoute) error {
+						if route.Dest != "test-subject" {
+							return fmt.Errorf("expected route dest test-subject, got %s", route.Dest)
+						}
+						if len(route.Monitors) != 1 {
+							return fmt.Errorf("expected 1 monitor, got %d", len(route.Monitors))
+						}
+
+						monitor := route.Monitors[0]
+						if !monitor.Enabled || monitor.Name != "tcp-probe" || monitor.Protocol != "tcp" || monitor.Dest != "10.100.0.10" || monitor.Port == nil || *monitor.Port != 443 || monitor.Interval != 5 || monitor.Count != 3 || monitor.MaxLatency == nil || *monitor.MaxLatency != 500 {
+							return fmt.Errorf("unexpected monitor: %+v", monitor)
+						}
+
+						return nil
+					}),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					compareValuesSame.AddStateValue("tg_virtual_network_route.test", tfjsonpath.New("id")),
+				},
+			},
+			{
+				Config: vnetRouteUpdatedConfig(networkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("tg_virtual_network_route.test", "id"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "dest", "another-subject"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "network_cidr", "10.10.24.0/24"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "metric", "11"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "description", "Updated Test Virtual Network Route"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "monitor.0.name", "icmp-probe"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "monitor.0.enabled", "true"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "monitor.0.protocol", "icmp"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "monitor.0.dest", "10.100.0.11"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "monitor.0.interval", "10"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "monitor.0.count", "2"),
+					resource.TestCheckNoResourceAttr("tg_virtual_network_route.test", "monitor.0.port"),
+					checkVNetRouteAPISide(tgProvider, networkName, func(route tg.VNetRoute) error {
+						if route.Dest != "another-subject" {
+							return fmt.Errorf("expected route dest another-subject, got %s", route.Dest)
+						}
+						if len(route.Monitors) != 1 {
+							return fmt.Errorf("expected 1 monitor, got %d", len(route.Monitors))
+						}
+
+						monitor := route.Monitors[0]
+						if !monitor.Enabled || monitor.Name != "icmp-probe" || monitor.Protocol != "icmp" || monitor.Dest != "10.100.0.11" || monitor.Port != nil || monitor.Interval != 10 || monitor.Count != 2 {
+							return fmt.Errorf("unexpected monitor: %+v", monitor)
+						}
+
+						return nil
+					}),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					compareValuesSame.AddStateValue("tg_virtual_network_route.test", tfjsonpath.New("id")),
+				},
+			},
+		},
+	})
+}
+
+func vnetRouteConfig(networkName string) string {
+	return fmt.Sprintf(`
+resource "tg_virtual_network" "test" {
+  name         = %q
+  network_cidr = "10.10.0.0/16"
+  description  = "Test Virtual Network"
+  no_nat       = true
+}
+
+resource "tg_virtual_network_route" "test" {
+  network      = tg_virtual_network.test.name
+  dest         = "test-subject"
+  network_cidr = "10.10.24.24/32"
+  metric       = 10
+  description  = "Test Virtual Network Route"
+
+  monitor {
+    name        = "tcp-probe"
+    enabled     = true
+    protocol    = "tcp"
+    dest        = "10.100.0.10"
+    port        = 443
+    interval    = 5
+    count       = 3
+    max_latency = 500
+  }
+}
+`, networkName)
+}
+
+func vnetRouteUpdatedConfig(networkName string) string {
+	return fmt.Sprintf(`
+resource "tg_virtual_network" "test" {
+  name         = %q
+  network_cidr = "10.10.0.0/16"
+  description  = "Test Virtual Network"
+  no_nat       = true
+}
+
+resource "tg_virtual_network_route" "test" {
+  network      = tg_virtual_network.test.name
+  dest         = "another-subject"
+  network_cidr = "10.10.24.0/24"
+  metric       = 11
+  description  = "Updated Test Virtual Network Route"
+
+  monitor {
+    name     = "icmp-probe"
+    enabled  = true
+    protocol = "icmp"
+    dest     = "10.100.0.11"
+    interval = 10
+    count    = 2
+  }
+}
+`, networkName)
+}
+
+func checkVNetRouteAPISide(provider *schema.Provider, networkName string, check func(tg.VNetRoute) error) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := provider.Meta().(*tg.Client)
+		resourceState, ok := s.RootModule().Resources["tg_virtual_network_route.test"]
+		if !ok {
+			return fmt.Errorf("route resource not found in state")
+		}
+
+		routeID := resourceState.Primary.ID
+		routes := make([]tg.VNetRoute, 0)
+		if err := client.Get(context.Background(), "/v2/domain/"+client.Domain+"/network/"+networkName+"/route", &routes); err != nil {
+			return fmt.Errorf("error getting virtual network routes: %w", err)
+		}
+
+		for _, route := range routes {
+			if route.UID == routeID {
+				return check(route)
+			}
+		}
+
+		return fmt.Errorf("virtual network route %s not found", routeID)
+	}
+}

--- a/acctests/vnetroute_test.go
+++ b/acctests/vnetroute_test.go
@@ -76,7 +76,7 @@ func TestAccVNetRoute_HappyPath(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("tg_virtual_network_route.test", "id"),
 					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "network", networkName),
-					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "dest", "test-subject"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "dest", "test-cluster"),
 					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "network_cidr", "10.10.24.24/32"),
 					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "metric", "10"),
 					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "description", "Test Virtual Network Route"),
@@ -89,8 +89,8 @@ func TestAccVNetRoute_HappyPath(t *testing.T) {
 					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "monitor.0.count", "3"),
 					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "monitor.0.max_latency", "500"),
 					checkVNetRouteAPISide(tgProvider, networkName, func(route tg.VNetRoute) error {
-						if route.Dest != "test-subject" {
-							return fmt.Errorf("expected route dest test-subject, got %s", route.Dest)
+						if route.Dest != "test-cluster" {
+							return fmt.Errorf("expected route dest test-cluster, got %s", route.Dest)
 						}
 						if len(route.Monitors) != 1 {
 							return fmt.Errorf("expected 1 monitor, got %d", len(route.Monitors))
@@ -112,7 +112,7 @@ func TestAccVNetRoute_HappyPath(t *testing.T) {
 				Config: vnetRouteUpdatedConfig(networkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("tg_virtual_network_route.test", "id"),
-					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "dest", "test-subject"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "dest", "test-cluster"),
 					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "network_cidr", "10.10.24.0/24"),
 					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "metric", "11"),
 					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "description", "Updated Test Virtual Network Route"),
@@ -124,8 +124,8 @@ func TestAccVNetRoute_HappyPath(t *testing.T) {
 					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "monitor.0.count", "2"),
 					resource.TestCheckNoResourceAttr("tg_virtual_network_route.test", "monitor.0.port"),
 					checkVNetRouteAPISide(tgProvider, networkName, func(route tg.VNetRoute) error {
-						if route.Dest != "test-subject" {
-							return fmt.Errorf("expected route dest test-subject, got %s", route.Dest)
+						if route.Dest != "test-cluster" {
+							return fmt.Errorf("expected route dest test-cluster, got %s", route.Dest)
 						}
 						if len(route.Monitors) != 1 {
 							return fmt.Errorf("expected 1 monitor, got %d", len(route.Monitors))
@@ -157,13 +157,13 @@ resource "tg_virtual_network" "test" {
 }
 
 resource "tg_vpn_attachment" "test" {
-  node_id = %q
-  network = tg_virtual_network.test.name
+  cluster_fqdn = %q
+  network      = tg_virtual_network.test.name
 }
 
 resource "tg_virtual_network_route" "test" {
   network      = tg_vpn_attachment.test.network
-  dest         = "test-subject"
+  dest         = "test-cluster"
   network_cidr = "10.10.24.24/32"
   metric       = 10
   description  = "Test Virtual Network Route"
@@ -179,7 +179,7 @@ resource "tg_virtual_network_route" "test" {
     max_latency = 500
   }
 }
-`, networkName, testNodeID)
+`, networkName, testClusterFQDN)
 }
 
 func vnetRouteUpdatedConfig(networkName string) string {
@@ -192,13 +192,13 @@ resource "tg_virtual_network" "test" {
 }
 
 resource "tg_vpn_attachment" "test" {
-  node_id = %q
-  network = tg_virtual_network.test.name
+  cluster_fqdn = %q
+  network      = tg_virtual_network.test.name
 }
 
 resource "tg_virtual_network_route" "test" {
   network      = tg_vpn_attachment.test.network
-  dest         = "test-subject"
+  dest         = "test-cluster"
   network_cidr = "10.10.24.0/24"
   metric       = 11
   description  = "Updated Test Virtual Network Route"
@@ -212,7 +212,7 @@ resource "tg_virtual_network_route" "test" {
     count    = 2
   }
 }
-`, networkName, testNodeID)
+`, networkName, testClusterFQDN)
 }
 
 func checkVNetRouteAPISide(provider *schema.Provider, networkName string, check func(tg.VNetRoute) error) resource.TestCheckFunc {

--- a/acctests/vnetroute_test.go
+++ b/acctests/vnetroute_test.go
@@ -112,7 +112,7 @@ func TestAccVNetRoute_HappyPath(t *testing.T) {
 				Config: vnetRouteUpdatedConfig(networkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("tg_virtual_network_route.test", "id"),
-					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "dest", "another-subject"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "dest", "test-subject"),
 					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "network_cidr", "10.10.24.0/24"),
 					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "metric", "11"),
 					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "description", "Updated Test Virtual Network Route"),
@@ -124,8 +124,8 @@ func TestAccVNetRoute_HappyPath(t *testing.T) {
 					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "monitor.0.count", "2"),
 					resource.TestCheckNoResourceAttr("tg_virtual_network_route.test", "monitor.0.port"),
 					checkVNetRouteAPISide(tgProvider, networkName, func(route tg.VNetRoute) error {
-						if route.Dest != "another-subject" {
-							return fmt.Errorf("expected route dest another-subject, got %s", route.Dest)
+						if route.Dest != "test-subject" {
+							return fmt.Errorf("expected route dest test-subject, got %s", route.Dest)
 						}
 						if len(route.Monitors) != 1 {
 							return fmt.Errorf("expected 1 monitor, got %d", len(route.Monitors))
@@ -156,8 +156,13 @@ resource "tg_virtual_network" "test" {
   no_nat       = true
 }
 
+resource "tg_vpn_attachment" "test" {
+  node_id = %q
+  network = tg_virtual_network.test.name
+}
+
 resource "tg_virtual_network_route" "test" {
-  network      = tg_virtual_network.test.name
+  network      = tg_vpn_attachment.test.network
   dest         = "test-subject"
   network_cidr = "10.10.24.24/32"
   metric       = 10
@@ -174,7 +179,7 @@ resource "tg_virtual_network_route" "test" {
     max_latency = 500
   }
 }
-`, networkName)
+`, networkName, testNodeID)
 }
 
 func vnetRouteUpdatedConfig(networkName string) string {
@@ -186,9 +191,14 @@ resource "tg_virtual_network" "test" {
   no_nat       = true
 }
 
+resource "tg_vpn_attachment" "test" {
+  node_id = %q
+  network = tg_virtual_network.test.name
+}
+
 resource "tg_virtual_network_route" "test" {
-  network      = tg_virtual_network.test.name
-  dest         = "another-subject"
+  network      = tg_vpn_attachment.test.network
+  dest         = "test-subject"
   network_cidr = "10.10.24.0/24"
   metric       = 11
   description  = "Updated Test Virtual Network Route"
@@ -202,7 +212,7 @@ resource "tg_virtual_network_route" "test" {
     count    = 2
   }
 }
-`, networkName)
+`, networkName, testNodeID)
 }
 
 func checkVNetRouteAPISide(provider *schema.Provider, networkName string, check func(tg.VNetRoute) error) resource.TestCheckFunc {

--- a/acctests/vnetroute_test.go
+++ b/acctests/vnetroute_test.go
@@ -122,7 +122,7 @@ func TestAccVNetRoute_HappyPath(t *testing.T) {
 					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "monitor.0.dest", "10.100.0.11"),
 					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "monitor.0.interval", "10"),
 					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "monitor.0.count", "2"),
-					resource.TestCheckNoResourceAttr("tg_virtual_network_route.test", "monitor.0.port"),
+					resource.TestCheckResourceAttr("tg_virtual_network_route.test", "monitor.0.port", "0"),
 					checkVNetRouteAPISide(tgProvider, networkName, func(route tg.VNetRoute) error {
 						if route.Dest != "test-cluster" {
 							return fmt.Errorf("expected route dest test-cluster, got %s", route.Dest)

--- a/acctests/vnetroute_test.go
+++ b/acctests/vnetroute_test.go
@@ -132,7 +132,11 @@ func TestAccVNetRoute_HappyPath(t *testing.T) {
 						}
 
 						monitor := route.Monitors[0]
-						if !monitor.Enabled || monitor.Name != "icmp-probe" || monitor.Protocol != "icmp" || monitor.Dest != "10.100.0.11" || monitor.Port != nil || monitor.Interval != 10 || monitor.Count != 2 {
+						port := 0
+						if monitor.Port != nil {
+							port = *monitor.Port
+						}
+						if !monitor.Enabled || monitor.Name != "icmp-probe" || monitor.Protocol != "icmp" || monitor.Dest != "10.100.0.11" || port != 0 || monitor.Interval != 10 || monitor.Count != 2 {
 							return fmt.Errorf("unexpected monitor: %+v", monitor)
 						}
 

--- a/docs/resources/virtual_network_route.md
+++ b/docs/resources/virtual_network_route.md
@@ -19,6 +19,17 @@ resource "tg_virtual_network_route" "route1" {
   network_cidr = "10.10.10.14/32"
   metric       = 1
   description  = "my edge node route"
+
+  monitor {
+    name        = "tcp-probe"
+    enabled     = true
+    protocol    = "tcp"
+    dest        = "10.100.0.10"
+    port        = 443
+    interval    = 5
+    count       = 3
+    max_latency = 500
+  }
 }
 ```
 
@@ -35,8 +46,26 @@ resource "tg_virtual_network_route" "route1" {
 ### Optional
 
 - `description` (String) Description
+- `monitor` (Block List) Route monitors that can deactivate the route when a probe target becomes unreachable (see [below for nested schema](#nestedblock--monitor))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
 - `uid` (String) Unique identifier of the route
+
+<a id="nestedblock--monitor"></a>
+### Nested Schema for `monitor`
+
+Required:
+
+- `count` (Number) Consecutive failures before the route is deactivated
+- `dest` (String) Destination IP to probe
+- `enabled` (Boolean) Monitor enabled state. Must be set to true because the API defaults new monitors to false
+- `interval` (Number) Probe interval in seconds
+- `name` (String) Unique name for the route monitor
+- `protocol` (String) Probe protocol
+
+Optional:
+
+- `max_latency` (Number) Maximum acceptable probe latency in milliseconds
+- `port` (Number) Destination port for TCP probes

--- a/examples/resources/tg_virtual_network_route/resource.tf
+++ b/examples/resources/tg_virtual_network_route/resource.tf
@@ -4,4 +4,15 @@ resource "tg_virtual_network_route" "route1" {
   network_cidr = "10.10.10.14/32"
   metric       = 1
   description  = "my edge node route"
+
+  monitor {
+    name        = "tcp-probe"
+    enabled     = true
+    protocol    = "tcp"
+    dest        = "10.100.0.10"
+    port        = 443
+    interval    = 5
+    count       = 3
+    max_latency = 500
+  }
 }

--- a/hcl/encoder.go
+++ b/hcl/encoder.go
@@ -70,6 +70,12 @@ func convertToMap(in any) (map[string]any, error) {
 				}
 			}
 			out[tf] = slice
+		case reflect.Pointer:
+			value := reflect.ValueOf(in).FieldByIndex([]int{i})
+			if value.IsNil() {
+				continue
+			}
+			out[tf] = value.Elem().Interface()
 		default:
 			out[tf] = reflect.ValueOf(in).FieldByIndex([]int{i}).Interface()
 		}

--- a/resource/vnetroute.go
+++ b/resource/vnetroute.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -24,6 +25,7 @@ func VNetRoute() *schema.Resource {
 		UpdateContext: r.Update,
 		DeleteContext: r.Delete,
 		CreateContext: r.Create,
+		CustomizeDiff: validateVNetRouteDiff,
 
 		Schema: map[string]*schema.Schema{
 			"uid": {
@@ -58,8 +60,113 @@ func VNetRoute() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 			},
+			"monitor": {
+				Description: "Route monitors that can deactivate the route when a probe target becomes unreachable",
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Description: "Unique name for the route monitor",
+							Type:        schema.TypeString,
+							Required:    true,
+						},
+						"enabled": {
+							Description: "Monitor enabled state. Must be set to true because the API defaults new monitors to false",
+							Type:        schema.TypeBool,
+							Required:    true,
+						},
+						"protocol": {
+							Description:  "Probe protocol",
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice([]string{"tcp", "icmp"}, false),
+						},
+						"dest": {
+							Description:  "Destination IP to probe",
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.IsIPAddress,
+						},
+						"port": {
+							Description:  "Destination port for TCP probes",
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IsPortNumber,
+						},
+						"interval": {
+							Description:  "Probe interval in seconds",
+							Type:         schema.TypeInt,
+							Required:     true,
+							ValidateFunc: validation.IntAtLeast(1),
+						},
+						"count": {
+							Description:  "Consecutive failures before the route is deactivated",
+							Type:         schema.TypeInt,
+							Required:     true,
+							ValidateFunc: validation.IntAtLeast(1),
+						},
+						"max_latency": {
+							Description: "Maximum acceptable probe latency in milliseconds",
+							Type:        schema.TypeInt,
+							Optional:    true,
+						},
+					},
+				},
+			},
 		},
 	}
+}
+
+func validateVNetRouteDiff(_ context.Context, d *schema.ResourceDiff, _ any) error {
+	monitors, ok := d.GetOk("monitor")
+	if !ok {
+		return nil
+	}
+
+	monitorList, ok := monitors.([]any)
+	if !ok {
+		return fmt.Errorf("monitor has invalid type %T", monitors)
+	}
+
+	if err := validateVNetRouteMonitors(monitorList); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateVNetRouteMonitors(monitors []any) error {
+	for i, rawMonitor := range monitors {
+		monitor, ok := rawMonitor.(map[string]any)
+		if !ok {
+			return fmt.Errorf("monitor %d has invalid type %T", i, rawMonitor)
+		}
+
+		enabled, ok := monitor["enabled"].(bool)
+		if !ok || !enabled {
+			return fmt.Errorf("monitor %d enabled must be true", i)
+		}
+
+		protocol, ok := monitor["protocol"].(string)
+		if !ok {
+			return fmt.Errorf("monitor %d protocol is required", i)
+		}
+
+		port, _ := monitor["port"].(int)
+		switch protocol {
+		case "tcp":
+			if port < 1 {
+				return fmt.Errorf("monitor %d port is required when protocol is tcp", i)
+			}
+		case "icmp":
+			if port > 0 {
+				return fmt.Errorf("monitor %d port must not be set when protocol is icmp", i)
+			}
+		}
+	}
+
+	return nil
 }
 
 func (vn *vnetRoute) findRoute(ctx context.Context, tgc *tg.Client, route tg.VNetRoute) (tg.VNetRoute, error) {
@@ -87,6 +194,15 @@ func (vn *vnetRoute) findRoute(ctx context.Context, tgc *tg.Client, route tg.VNe
 
 func (vn *vnetRoute) Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	tgc := tg.GetClient(meta)
+
+	monitors, ok := d.Get("monitor").([]any)
+	if !ok {
+		return diag.FromErr(fmt.Errorf("monitor has invalid type %T", d.Get("monitor")))
+	}
+
+	if err := validateVNetRouteMonitors(monitors); err != nil {
+		return diag.FromErr(err)
+	}
 
 	route, err := hcl.DecodeResourceData[tg.VNetRoute](d)
 	if err != nil {
@@ -119,6 +235,15 @@ func (vn *vnetRoute) Create(ctx context.Context, d *schema.ResourceData, meta an
 
 func (vn *vnetRoute) Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	tgc := tg.GetClient(meta)
+
+	monitors, ok := d.Get("monitor").([]any)
+	if !ok {
+		return diag.FromErr(fmt.Errorf("monitor has invalid type %T", d.Get("monitor")))
+	}
+
+	if err := validateVNetRouteMonitors(monitors); err != nil {
+		return diag.FromErr(err)
+	}
 
 	route, err := hcl.DecodeResourceData[tg.VNetRoute](d)
 	if err != nil {

--- a/resource/vnetroute_test.go
+++ b/resource/vnetroute_test.go
@@ -1,0 +1,157 @@
+package resource
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/trustgrid/terraform-provider-tg/hcl"
+	"github.com/trustgrid/terraform-provider-tg/tg"
+)
+
+func intPointer(v int) *int {
+	return &v
+}
+
+func TestValidateVNetRouteMonitors(t *testing.T) {
+	tests := []struct {
+		name     string
+		monitors []any
+		err      string
+	}{
+		{
+			name: "tcp valid",
+			monitors: []any{map[string]any{
+				"name":        "tcp-probe",
+				"enabled":     true,
+				"protocol":    "tcp",
+				"dest":        "10.100.0.10",
+				"port":        443,
+				"interval":    5,
+				"count":       3,
+				"max_latency": 500,
+			}},
+		},
+		{
+			name: "icmp valid",
+			monitors: []any{map[string]any{
+				"name":     "icmp-probe",
+				"enabled":  true,
+				"protocol": "icmp",
+				"dest":     "10.100.0.10",
+				"interval": 5,
+				"count":    3,
+			}},
+		},
+		{
+			name: "enabled must be true",
+			monitors: []any{map[string]any{
+				"name":     "icmp-probe",
+				"enabled":  false,
+				"protocol": "icmp",
+				"dest":     "10.100.0.10",
+				"interval": 5,
+				"count":    3,
+			}},
+			err: "enabled must be true",
+		},
+		{
+			name: "tcp requires port",
+			monitors: []any{map[string]any{
+				"name":     "tcp-probe",
+				"enabled":  true,
+				"protocol": "tcp",
+				"dest":     "10.100.0.10",
+				"interval": 5,
+				"count":    3,
+			}},
+			err: "port is required when protocol is tcp",
+		},
+		{
+			name: "icmp forbids port",
+			monitors: []any{map[string]any{
+				"name":     "icmp-probe",
+				"enabled":  true,
+				"protocol": "icmp",
+				"dest":     "10.100.0.10",
+				"port":     443,
+				"interval": 5,
+				"count":    3,
+			}},
+			err: "port must not be set when protocol is icmp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateVNetRouteMonitors(tt.monitors)
+			if tt.err == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.err)
+		})
+	}
+}
+
+func TestVNetRouteMonitorEncodeDecode(t *testing.T) {
+	res := VNetRoute()
+	d := (&schema.Resource{Schema: res.Schema}).TestResourceData()
+
+	err := d.Set("network", "test-network")
+	require.NoError(t, err)
+	err = d.Set("dest", "edge-node")
+	require.NoError(t, err)
+	err = d.Set("network_cidr", "10.10.10.14/32")
+	require.NoError(t, err)
+	err = d.Set("metric", 1)
+	require.NoError(t, err)
+	err = d.Set("description", "my edge node route")
+	require.NoError(t, err)
+	err = d.Set("monitor", []map[string]any{{
+		"name":        "tcp-probe",
+		"enabled":     true,
+		"protocol":    "tcp",
+		"dest":        "10.100.0.10",
+		"port":        443,
+		"interval":    5,
+		"count":       3,
+		"max_latency": 500,
+	}})
+	require.NoError(t, err)
+
+	route, err := hcl.DecodeResourceData[tg.VNetRoute](d)
+	require.NoError(t, err)
+	require.Len(t, route.Monitors, 1)
+	assert.Equal(t, tg.VNetRouteMonitor{
+		Name:       "tcp-probe",
+		Enabled:    true,
+		Protocol:   "tcp",
+		Dest:       "10.100.0.10",
+		Port:       intPointer(443),
+		Interval:   5,
+		Count:      3,
+		MaxLatency: intPointer(500),
+	}, route.Monitors[0])
+
+	route.UID = "route-uid"
+	d = (&schema.Resource{Schema: res.Schema}).TestResourceData()
+	err = hcl.EncodeResourceData(route, d)
+	require.NoError(t, err)
+
+	assert.Equal(t, "route-uid", d.Get("uid"))
+	monitors := d.Get("monitor").([]any)
+	require.Len(t, monitors, 1)
+	monitor := monitors[0].(map[string]any)
+	assert.Equal(t, "tcp-probe", monitor["name"])
+	assert.Equal(t, true, monitor["enabled"])
+	assert.Equal(t, "tcp", monitor["protocol"])
+	assert.Equal(t, "10.100.0.10", monitor["dest"])
+	assert.Equal(t, 443, monitor["port"])
+	assert.Equal(t, 5, monitor["interval"])
+	assert.Equal(t, 3, monitor["count"])
+	assert.Equal(t, 500, monitor["max_latency"])
+}

--- a/tg/virtualnetwork.go
+++ b/tg/virtualnetwork.go
@@ -12,10 +12,22 @@ type VNetRoute struct {
 	UID         string `tf:"uid" json:"uid"`
 	NetworkName string `tf:"network" json:"-"`
 
-	NetworkCIDR string `tf:"network_cidr" json:"networkCidr"`
-	Dest        string `tf:"dest" json:"nodeName"`
-	Metric      int    `tf:"metric" json:"metric"`
-	Description string `tf:"description" json:"description"`
+	NetworkCIDR string             `tf:"network_cidr" json:"networkCidr"`
+	Dest        string             `tf:"dest" json:"nodeName"`
+	Metric      int                `tf:"metric" json:"metric"`
+	Description string             `tf:"description" json:"description"`
+	Monitors    []VNetRouteMonitor `tf:"monitor" json:"monitors,omitempty"`
+}
+
+type VNetRouteMonitor struct {
+	Enabled    bool   `tf:"enabled" json:"enabled"`
+	Name       string `tf:"name" json:"name"`
+	Protocol   string `tf:"protocol" json:"protocol"`
+	Dest       string `tf:"dest" json:"dest"`
+	Port       *int   `tf:"port,omitempty" json:"port,omitempty"`
+	Interval   int    `tf:"interval" json:"interval"`
+	Count      int    `tf:"count" json:"count"`
+	MaxLatency *int   `tf:"max_latency,omitempty" json:"maxLatency,omitempty"`
 }
 
 type VNetPortForward struct {


### PR DESCRIPTION
## Summary
- add inline `monitor` block support to `tg_virtual_network_route` and map monitor payloads to the virtual network route API
- validate monitor configuration so TCP probes require a port, ICMP probes reject one, and monitors must be explicitly enabled
- add tests plus docs and example updates, including pointer-safe state encoding to avoid bogus drift for optional monitor fields

## Testing
- go test ./...
- golangci-lint run --tests=false ./...
- make docs